### PR TITLE
[Feature] Update action to use node 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
 
 ### Requirements:
 
-* NodeJS 12+
+* NodeJS 20+
 
 ### Setup
 

--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ branding:
   color: 'blue'
 
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-pr-title",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "action-pr-title",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-pr-title",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "action-pr-title",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.2.6",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/chai": "^4.2.15",
         "@types/mocha": "^8.2.2",
-        "@types/node": "^12",
+        "@types/node": "^20.8.7",
         "@typescript-eslint/eslint-plugin": "^4.18.0",
         "@typescript-eslint/parser": "^4.18.0",
         "@vercel/ncc": "^0.27.0",
@@ -379,10 +379,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.6.tgz",
-      "integrity": "sha512-sRVq8d+ApGslmkE9e3i+D3gFGk7aZHAT+G4cIpIEdLJYPsWiSPwcAnJEjddLQQDqV3Ra2jOclX/Sv6YrvGYiWA==",
-      "dev": true
+      "version": "20.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.18.0",
@@ -3574,6 +3577,12 @@
         "which-boxed-primitive": "^1.0.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "dev": true
+    },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
@@ -4158,10 +4167,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.6.tgz",
-      "integrity": "sha512-sRVq8d+ApGslmkE9e3i+D3gFGk7aZHAT+G4cIpIEdLJYPsWiSPwcAnJEjddLQQDqV3Ra2jOclX/Sv6YrvGYiWA==",
-      "dev": true
+      "version": "20.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.25.1"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.18.0",
@@ -6472,6 +6484,12 @@
         "has-symbols": "^1.0.0",
         "which-boxed-primitive": "^1.0.1"
       }
+    },
+    "undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "dev": true
     },
     "universal-user-agent": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.15",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^12",
+    "@types/node": "^20.8.7",
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
     "@vercel/ncc": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-pr-title",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "GitHub action to validate PR titles meet our guidelines",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Related to Issue [#9895](https://github.com/Submitty/Submitty/issues/9895)

The following changes have been made because GitHub Actions will no longer support Node.js v12, as mentioned by @williamjallen in the linked issue. You can find the relevant information in the blog post referenced in that issue.

1. Updated `action.yml` so that it uses Node.js version `'node20'`
2. Updated `README.md` to reflect this change
3. Updated `test.yml` matrix node-version array to `[20.x]`
4. Updated version to `2.0.0` in package.json to reflect this change, as this is a breaking change, according to the rules of [semantic versioning](https://docs.npmjs.com/about-semantic-versioning)
5. Upgraded `@types/node` version to `"^20.8.7"` to match Node.js v20 version

I have conducted a search for other repositories using Node.js v12 and identified the following three repositories, so I have opened other PRs updating Node.js to v20 in them:

- [x] [pdf-annotate](https://github.com/Submitty/pdf-annotate.js/pull/626)
- [x] [peter-evans-create-pull-request](https://github.com/Submitty/peter-evans-create-pull-request/pull/1)
- [x] [peter-evans-repository-dispatch](https://github.com/Submitty/peter-evans-repository-dispatch/pull/1)

### Checks:

[x] Have run `npm run lint` and `npm run test` as specified in the `README.md`

P.S. If this PR is accepted, could you please add the "hacktoberfest-accepted" label to it, so that it counts towards my Hacktoberfest contributions?