### PR TITLE
Functionality to generate Standard PR titles

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -126,3 +126,33 @@ export function checkTitle(fullTitle: string): true {
 
   return true;
 }
+
+export function formatPRTitle(
+  type: string,
+  module: string,
+  subject: string
+): string {
+  if (!allowedTypes.includes(type)) {
+    throw new Error(
+      `Invalid type, expected one of ${allowedTypes.join(", ")}. Got ${type}.`
+    );
+  }
+
+  if (!allowedModules.includes(module)) {
+    throw new Error(
+      `Invalid module, expected one of ${allowedModules.join(
+        ", "
+      )}. Got ${module}.`
+    );
+  }
+
+  const prTitle = `[${type}:${module}] ${subject}`;
+  const maxLegnth = 50;
+  if (prTitle.length > maxLegnth) {
+    throw new Error(
+      `PR title exceeds the maximum allowed length of ${maxLegnth} characters.`
+    );
+  }
+
+  return prTitle;
+}

--- a/test/validate.spec.ts
+++ b/test/validate.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from "chai";
-import { allowedModules, allowedTypes, checkTitle } from "../src/validate";
+import {
+  allowedModules,
+  allowedTypes,
+  checkTitle,
+  formatPRTitle,
+} from "../src/validate";
 
 describe("validate", () => {
   describe("checkTitle", () => {
@@ -144,6 +149,18 @@ describe("validate", () => {
   - Invalid module, expected one of Submission, Autograding, Forum, Notifications, TAGrading, InstructorUI, SubminiPolls, HelpQueue, CourseMaterials, Plagiarism, RainbowGrades, Calendar, System, Developer, API. Got Error.
   - Too long a message, expected at most 40 characters, got 56 characters.`);
       });
+    });
+  });
+
+  describe("formatPRTitle", () => {
+    it("should format PR Title correctly", () => {
+      const type = "Feature";
+      const module = "Submission";
+      const subject = "Add support for file uploads";
+
+      const formattedTitle = formatPRTitle(type, module, subject);
+      const expectedTitle = `[${type}:${module}] ${subject}`;
+      expect(formattedTitle).to.equal(expectedTitle);
     });
   });
 });


### PR DESCRIPTION
### Functionality:
We can then use this function to generate PR titles in a standardized manner before submitting a PR. 

### Solution:
Added a function that takes the type, module, and subject as input and generates a formatted PR title in validate.ts. This function should also perform length checks and exclude the issue # if present. Have added the method to test the function in spec.ts

### Risk level:
- [ ] high 
- [x] medium
- [ ] low

### How to test:
Add a console in the method in spec to print formattedTitle
ng run test

### Screenshots
![Screenshot from 2024-01-21 15-07-24](https://github.com/Submitty/action-pr-title/assets/95395832/272e8c26-6a5b-4705-8bbb-bf5e697a13fe)